### PR TITLE
Document using python2's web server for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ file in your browser and work on it - you need a very simple HTTP server.
 On your terminal, run the following command:
 
 ```bash
+python -m SimpleHTTPServer
+```
+
+If this gives you errors, try:
+
+```bash
 python3 -m http.server
 ```
 


### PR DESCRIPTION
Unfortunately, python3 isn't part of the default Mac OS install.

Based on @prtksxna's comment in #10 